### PR TITLE
Ignore actions-user as a contributor

### DIFF
--- a/.github/workflows/auto-add-contributors.yml
+++ b/.github/workflows/auto-add-contributors.yml
@@ -22,3 +22,4 @@ jobs:
           PATH: "/README.md"
           COMMIT_MESSAGE: "docs(README): update contributors"
           AVATAR_SHAPE: "round"
+          IGNORED_CONTRIBUTORS: "actions-user"


### PR DESCRIPTION
Resolves #21

Removes actions-user from the contributor list.