### PR TITLE
Bump deprecated function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,13 @@ var brackets = {
 
   detectURIArgs: () => {
     let url = window.location.href;
+    let urlArgs = url.split("?");
+    let args = urlArgs[1].split("&");
+    let argsObj = {};
+    for (let i = 0; i < args.length; i++) {
+      let arg = args[i].split("=");
+      argsObj[arg[0]] = arg[1];
+    }
 
     console.log(argsObj);
     return argsObj;

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ var brackets = {
 
   toggleClass: (id, className) => {
     let elem = document.getElementById(id);
-    if (elem.classList.contains(className)) {
+    if (elem.classList.includes(className)) {
       elem.classList.remove(className);
     } else {
       elem.classList.add(className);
@@ -109,13 +109,7 @@ var brackets = {
 
   detectURIArgs: () => {
     let url = window.location.href;
-    let urlArgs = url.split("?");
-    let args = urlArgs[1].split("&");
-    let argsObj = {};
-    for (let i = 0; i < args.length; i++) {
-      let arg = args[i].split("=");
-      argsObj[arg[0]] = arg[1];
-    }
+
     console.log(argsObj);
     return argsObj;
   },


### PR DESCRIPTION
`String.prototype.contains` is deprecated. This pull request replaces it with the correct function; `String.prototype.includes`